### PR TITLE
Fix #1 : déplacement login:pwd dans App.config

### DIFF
--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -25,7 +25,7 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = System.Configuration.ConfigurationManager.AppSettings["apiCredentials"];
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)


### PR DESCRIPTION
Déplacement du couple login:pwd de l'API depuis Access.cs vers App.config pour éviter de laisser des identifiants en dur dans le code source.